### PR TITLE
Remove erroneous `needs:` from publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,6 @@ on:
     types: [published]
 jobs:
   build:
-    needs: tests
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
I really need to get the yaml language server working in Kate.